### PR TITLE
Fix window checks in admin pages

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -31,7 +31,7 @@ const AdminPage = (props: Props) => {
   }, [authUser?.id]);
 
   useEffect(() => {
-    if (typeof window !== undefined && !authUser) {
+    if (typeof window !== 'undefined' && !authUser) {
       router.push("/login");
     } else {
       fetchingPosts();

--- a/pages/admin/post/[id].tsx
+++ b/pages/admin/post/[id].tsx
@@ -25,7 +25,7 @@ const PostPage = (props :any) => {
   const { addToast } = useToasts();
   const [post, setPost] = useState<any>({});
   useEffect(() => {
-    if (typeof window !== undefined && !authUser) {
+    if (typeof window !== 'undefined' && !authUser) {
       router.push("/login");
     }
   }, [authUser, router]);

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -32,7 +32,7 @@ function Login(props: Props) {
   }, [firstInput]);
 
 
-  if (typeof window !== undefined && props?.AuthUserInfo?.token) {
+  if (typeof window !== 'undefined' && props?.AuthUserInfo?.token) {
     return router.push("/admin");
   }
 


### PR DESCRIPTION
## Summary
- ensure the `typeof window` comparison uses the correct string literal

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6846f23ce2548324b42e79b7a5c66fd5