### PR TITLE
Change display font to Inter

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,12 +1,12 @@
 import { ReactNode } from 'react';
 import Head from "next/head";
-import { Cormorant_Garamond, Inter } from '@next/font/google';
+import { Inter } from '@next/font/google';
 
 import config from 'config';
 import Sidebar from "components/Sidebar";
 import MainContent from "components/MainContent";
 
-const displayFont = Cormorant_Garamond({
+const displayFont = Inter({
   weight: ['400', '500'],
   display: 'swap',
   subsets: ['latin'],

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,7 +19,7 @@ body {
 }
 
 h1, h2, h3, h4 {
-  font-family: var(--font-display), 'Cormorant Garamond', Garamond, 'Times New Roman', serif;
+  font-family: var(--font-display), Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 .intro a {
@@ -87,7 +87,7 @@ h1, h2, h3, h4 {
 .post-content h2,
 .post-content h3,
 .post-content h4 {
-  font-family: var(--font-display), 'Cormorant Garamond', Garamond, serif;
+  font-family: var(--font-display), Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-weight: 400;
   letter-spacing: -0.02em;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,7 @@ module.exports = {
       xl: '1280px',
     },
     fontFamily: {
-      display: ['var(--font-display)', 'Cormorant Garamond', 'Tiempos Headline', 'Garamond', 'Times New Roman', 'serif'],
+      display: ['var(--font-display)', 'Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
       body: ['var(--font-body)', 'Inter', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
       mono: ['JetBrains Mono', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
     },


### PR DESCRIPTION
Replaced the `Cormorant_Garamond` display font with `Inter` in `components/Layout.tsx`. Also updated the fallback font family stack for the `display` font in both `styles/globals.css` and `tailwind.config.js` to correctly fall back to sans-serif fonts instead of serif fonts.

---
*PR created automatically by Jules for task [777616272344998422](https://jules.google.com/task/777616272344998422) started by @vyquocvu*